### PR TITLE
Remove css height for finders at passfault.css

### DIFF
--- a/jsonService/src/main/webapp/passfault.css
+++ b/jsonService/src/main/webapp/passfault.css
@@ -215,7 +215,6 @@ body {
 	clear: both;
 	padding: 1.5em;
 	max-width: 48em;
-	height: 100em;
 }
 
 .pattern {

--- a/jsonService/src/main/webapp/passfault.css
+++ b/jsonService/src/main/webapp/passfault.css
@@ -223,6 +223,14 @@ body {
 	height: 8em;
 }
 
+.clickable {
+	cursor: pointer;
+}
+
+.clickable label {
+	cursor: pointer;
+}
+
 .passSummary {
 	font-family: road_em;
 	margin-bottom: 10px;
@@ -349,10 +357,16 @@ div.menu {
                 no-repeat;
 }
 
+/* Force vertical scrollbar to avoid horizontal
+   shaking when pattern details appear */
+body {
+    overflow-y: scroll;
+}
+
 /* When the body has the loading class, we turn
    the scrollbar off with overflow:hidden */
 body.loading {
-    overflow: hidden;   
+    overflow: hidden !important;
 }
 
 /* Anytime the body has the loading class, our

--- a/jsonService/src/main/webapp/passfault.js
+++ b/jsonService/src/main/webapp/passfault.js
@@ -144,17 +144,18 @@ String.prototype.supplant = function (o) {
     );
 };
 
-passfault.showDetail = function (id){
-	$("div.patternDetail").hide();
-	$("#"+id).show();
-}
-
-passfault.hideDetail = function (id){
-	$("#"+id).hide();
+passfault.toggleDetailVisible = function (id){
+	if( $("#"+id).is(':visible') ) {
+		$("#"+id).hide();
+	} else {
+		$("div.patternDetail").hide();
+		$("#"+id).show();
+		window.scrollTo(0,document.body.scrollHeight);
+	}
 }
 
 passfault.passwordPatternTemplate =
-'<div class="sign white pattern" onmouseout="passfault.hideDetail(\'{id}\')" onmouseover="passfault.showDetail(\'{id}\')">'+
+'<div class="sign white pattern clickable" onClick="passfault.toggleDetailVisible(\'{id}\')" >'+
 	'<div class="normal"><label title="Found Pattern"/>{name}</div>' +
 	'<div class="small"><label title="Pattern Classification"/>{classification}</div>' +
 	'<div class="xxlarge">{percent}%</div>' +


### PR DESCRIPTION
This makes the main page to be dozens of em's higher than needed.
Am I missing something or this property has no use?